### PR TITLE
repopulated promote panel in backend

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -45,7 +45,7 @@ STREAMFIELD_DEFAULT_BLOCKS = [
 ]
 
 class TranslatedStreamFieldPage(Page):
-    
+
     title_en = models.CharField(max_length=255, blank=True, verbose_name="Header Title")
     title_de = models.CharField(max_length=255, blank=True, verbose_name="Header Title")
 
@@ -84,12 +84,16 @@ class TranslatedStreamFieldPage(Page):
     ]
 
     promote_panels = [
-        FieldPanel('slug'),
+        MultiFieldPanel([
+            FieldPanel('slug'),
+            FieldPanel('title'),
+        ],
+        heading = "Slug and CMS Page Name"),
         MultiFieldPanel([
             FieldPanel('seo_title'),
             FieldPanel('search_description'),
         ],
-        heading = "SEO settings de",
+        heading = "SEO settings",
         classname="collapsible"),
     ]
 
@@ -146,7 +150,11 @@ class HomePage(TranslatedStreamFieldPage):
     ]
 
     promote_panels = [
-        FieldPanel('slug'),
+        MultiFieldPanel([
+            FieldPanel('slug'),
+            FieldPanel('title'),
+        ],
+        heading = "Slug and CMS Page Name"),
         MultiFieldPanel([
             FieldPanel('seo_title'),
             FieldPanel('search_description'),
@@ -196,7 +204,11 @@ class TextPage(Page):
     ]
 
     promote_panels = [
-        FieldPanel('slug'),
+        MultiFieldPanel([
+            FieldPanel('slug'),
+            FieldPanel('title'),
+        ],
+        heading = "Slug and CMS Page Name"),
         MultiFieldPanel([
             FieldPanel('seo_title'),
             FieldPanel('search_description'),

--- a/projects/models.py
+++ b/projects/models.py
@@ -133,10 +133,24 @@ class ProjectPage(Page):
         FieldPanel('external_url_en'),
     ]
 
+    promote_panels = [
+        MultiFieldPanel([
+            FieldPanel('slug'),
+            FieldPanel('title'),
+        ],
+        heading = "Slug and CMS Page Name"),
+        MultiFieldPanel([
+            FieldPanel('seo_title'),
+            FieldPanel('search_description'),
+        ],
+        heading = "SEO settings",
+        classname="collapsible"),
+    ]
+
     edit_handler = TabbedInterface([
         ObjectList(de_content_panels, heading='Content de'),
         ObjectList(en_content_panels, heading='Content en'),
-        ObjectList(Page.promote_panels, heading='Promote'),
+        ObjectList(promote_panels, heading='Promote'),
         ObjectList(Page.settings_panels, heading='Settings', classname="settings"),
     ])
 


### PR DESCRIPTION
repopulated promote panel in backend:

- re-added non-translated "title" field, to force validation and auto-population of slug. This should prevent accidental empty slugs.
- also allows for Page Names in page tree that are user-friendly and independent from the (translated) page title needed in content

please check and close #7 #10 if issue solved
